### PR TITLE
feat: lsm + sst initial implementation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 max_log_size: 104857600  # 100 MB
 do_async_repair: false
-wal_dir: "/tmp/vitadb"
+wal_dir: "/tmp/vitadb/wal"
 use_segmented_logs: true
+memtable_size: 4194304 # 4MB, after which we flush to sst

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huandu/skiplist v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,9 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/skiplist v1.2.0 h1:gox56QD77HzSC0w+Ws3MH3iie755GBJU1OER3h5VsYw=
+github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXMrPiHF9w=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -50,6 +53,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -72,6 +76,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	WALDir           string `mapstructure:"wal_dir"`
 	UseSegmentedLogs bool   `mapstructure:"use_segmented_logs"`
 	SegmentSize      int    `mapstructure:"segment_size"`
+	SSTDir           string `mapstructure:"sst_dir"`
+	MemtableSize     int    `mapstructure:"memtable_size"`
 }
 
 func Load() (*Config, error) {
@@ -23,8 +25,10 @@ func Load() (*Config, error) {
 
 	viper.SetDefault("max_log_size", 104857600)
 	viper.SetDefault("do_async_repair", false)
-	viper.SetDefault("wal_dir", "/tmp/vitadb")
+	viper.SetDefault("wal_dir", "/tmp/vitadb/wal")
 	viper.SetDefault("segment_size", 1000)
+	viper.SetDefault("sst_dir", "/tmp/vitadb/sstables")
+	viper.SetDefault("memtable_size", 4*1024*1024) //4MB
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,7 @@ func TestLoad(t *testing.T) {
 		assert.NotNil(t, cfg)
 		assert.Equal(t, int64(104857600), cfg.MaxLogSize)
 		assert.Equal(t, cfg.DoAsyncRepair, false)
-		assert.Equal(t, "/tmp/vitadb", cfg.WALDir)
+		assert.Equal(t, "/tmp/vitadb/wal", cfg.WALDir)
 	})
 
 	t.Run("Load with env vars", func(t *testing.T) {
@@ -42,6 +42,6 @@ func TestLoad(t *testing.T) {
 		assert.NotNil(t, cfg)
 		assert.Equal(t, int64(104857600), cfg.MaxLogSize)
 		assert.False(t, cfg.DoAsyncRepair)
-		assert.Equal(t, "/tmp/vitadb", cfg.WALDir)
+		assert.Equal(t, "/tmp/vitadb/wal", cfg.WALDir)
 	})
 }

--- a/internal/lsm/lsm.go
+++ b/internal/lsm/lsm.go
@@ -1,0 +1,82 @@
+package lsm
+
+import (
+	"fmt"
+
+	"github.com/joobisb/vitadb/internal/config"
+)
+
+type LSM struct {
+	memtable *Memtable
+	config   *config.Config
+
+	// keep track of SSTables
+	sstables   []*SSTable
+	sstCounter int
+}
+
+func NewLSM(cfg *config.Config) (*LSM, error) {
+	return &LSM{
+		memtable:   NewMemtable(),
+		config:     cfg,
+		sstables:   make([]*SSTable, 0),
+		sstCounter: 0,
+	}, nil
+}
+
+func (l *LSM) Set(key, value string) error {
+
+	// insert into Memtable
+	l.memtable.Set(key, value)
+
+	// Check if Memtable needs to be flushed (we'll implement this later)
+	//TODO implement the concept of 2 active memtables
+	//when flushMemtable is called, we switch the active memtable and write the previous one to disk
+	if l.memtable.Size() >= l.config.MemtableSize {
+		if err := l.flushMemtable(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *LSM) flushMemtable() error {
+	ssTable, err := NewSSTable(l.config, l.sstCounter)
+	if err != nil {
+		return fmt.Errorf("failed to create new SSTable: %v", err)
+	}
+
+	// Iterate through the memtable and write entries to the SST file
+	err = l.memtable.Iterate(func(key, value string) error {
+		if err := ssTable.writeEntry(key, value); err != nil {
+			return fmt.Errorf("failed to write entry to SST: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Add the new SST to the list of SSTables
+	l.sstables = append(l.sstables, ssTable)
+	l.sstCounter++
+
+	// Create a new memtable
+	l.memtable = NewMemtable()
+
+	return nil
+}
+
+// Add this new method to iterate over the Memtable
+func (m *Memtable) Iterate(fn func(key, value string) error) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for e := m.data.Front(); e != nil; e = e.Next() {
+		if err := fn(e.Key().(string), e.Value.(string)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/lsm/lsm_test.go
+++ b/internal/lsm/lsm_test.go
@@ -1,0 +1,55 @@
+package lsm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joobisb/vitadb/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLSM(t *testing.T) {
+	cfg := &config.Config{MemtableSize: 1024}
+	lsm, err := NewLSM(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, lsm)
+	assert.Equal(t, cfg, lsm.config)
+	assert.NotNil(t, lsm.memtable)
+	assert.Empty(t, lsm.sstables)
+	assert.Equal(t, 0, lsm.sstCounter)
+}
+
+func TestLSMSet(t *testing.T) {
+	cfg := &config.Config{MemtableSize: 100, SSTDir: t.TempDir()}
+	lsm, _ := NewLSM(cfg)
+
+	err := lsm.Set("key1", "value1")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, lsm.memtable.data.Len())
+
+	// Test flushing memtable
+	for i := 0; i < 10; i++ {
+		err := lsm.Set(fmt.Sprintf("key%d", i), "long_value_to_trigger_flush")
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, 2, len(lsm.sstables))
+	assert.Equal(t, 2, lsm.sstCounter)
+}
+
+func TestLSMIterate(t *testing.T) {
+	m := NewMemtable()
+	m.Set("key1", "value1")
+	m.Set("key2", "value2")
+
+	count := 0
+	err := m.Iterate(func(key, value string) error {
+		count++
+		assert.Contains(t, []string{"key1", "key2"}, key)
+		assert.Contains(t, []string{"value1", "value2"}, value)
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+}

--- a/internal/lsm/memtable.go
+++ b/internal/lsm/memtable.go
@@ -1,0 +1,58 @@
+package lsm
+
+import (
+	"sync"
+
+	"github.com/huandu/skiplist"
+)
+
+type Memtable struct {
+	data *skiplist.SkipList
+	size int
+	mu   sync.RWMutex
+}
+
+func NewMemtable() *Memtable {
+
+	return &Memtable{
+		data: skiplist.New(skiplist.String),
+		size: 0,
+	}
+}
+
+func (m *Memtable) Set(key, value string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	oldValue := m.data.Get(key)
+	if oldValue != nil {
+		m.size -= len(oldValue.Value.(string))
+		m.size += len(value)
+	} else {
+		m.size += len(key) + len(value)
+	}
+	m.data.Set(key, value)
+
+}
+
+func (m *Memtable) Get(key string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	element := m.data.Get(key)
+	if element == nil {
+		return "", false
+	}
+
+	value, ok := element.Value.(string)
+	if !ok {
+		return "", false
+	}
+	return value, true
+}
+
+func (m *Memtable) Size() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.size
+}

--- a/internal/lsm/memtable_test.go
+++ b/internal/lsm/memtable_test.go
@@ -1,0 +1,47 @@
+package lsm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMemtable(t *testing.T) {
+	m := NewMemtable()
+	assert.NotNil(t, m)
+	assert.NotNil(t, m.data)
+	assert.Equal(t, 0, m.size)
+}
+
+func TestMemtableSetAndGet(t *testing.T) {
+	m := NewMemtable()
+
+	m.Set("key1", "value1")
+	m.Set("key2", "value2")
+
+	value, ok := m.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, "value1", value)
+
+	value, ok = m.Get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, "value2", value)
+
+	value, ok = m.Get("nonexistent")
+	assert.False(t, ok)
+	assert.Empty(t, value)
+}
+
+func TestMemtableSize(t *testing.T) {
+	m := NewMemtable()
+
+	m.Set("key1", "value1")
+	assert.Equal(t, len("key1")+len("value1"), m.Size())
+
+	m.Set("key2", "value2")
+	assert.Equal(t, len("key1")+len("value1")+len("key2")+len("value2"), m.Size())
+
+	// Update existing key
+	m.Set("key1", "newvalue1")
+	assert.Equal(t, len("key2")+len("value2")+len("key1")+len("newvalue1"), m.Size())
+}

--- a/internal/lsm/sst.go
+++ b/internal/lsm/sst.go
@@ -1,0 +1,63 @@
+package lsm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/joobisb/vitadb/internal/config"
+)
+
+type SSTable struct {
+	path string
+}
+
+func NewSSTable(cfg *config.Config, id int) (*SSTable, error) {
+	// Ensure the SST directory exists
+	if err := os.MkdirAll(cfg.SSTDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create WAL directory: %v", err)
+	}
+
+	path := filepath.Join(cfg.SSTDir, fmt.Sprintf("sst_%d.db", id))
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SST file: %v", err)
+	}
+	defer file.Close()
+
+	return &SSTable{path: path}, nil
+}
+
+// SST file format:
+// [key_size (4 bytes)][key][value_size (4 bytes)][value]...
+func (sst *SSTable) writeEntry(key, value string) error {
+	file, err := os.OpenFile(sst.path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open SST file: %v", err)
+	}
+	defer file.Close()
+
+	// Write key size
+	//This approach allows for keys and values of varying lengths, up to a maximum of 2^32 - 1 bytes.
+	if err := binary.Write(file, binary.LittleEndian, uint32(len(key))); err != nil {
+		return fmt.Errorf("failed to write key size: %v", err)
+	}
+
+	// Write key
+	if _, err := file.Write([]byte(key)); err != nil {
+		return fmt.Errorf("failed to write key: %v", err)
+	}
+
+	// Write value size
+	if err := binary.Write(file, binary.LittleEndian, uint32(len(value))); err != nil {
+		return fmt.Errorf("failed to write value size: %v", err)
+	}
+
+	// Write value
+	if _, err := file.Write([]byte(value)); err != nil {
+		return fmt.Errorf("failed to write value: %v", err)
+	}
+
+	return nil
+}

--- a/internal/lsm/sst_test.go
+++ b/internal/lsm/sst_test.go
@@ -1,0 +1,54 @@
+package lsm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joobisb/vitadb/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSSTable(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{SSTDir: tempDir}
+
+	sst, err := NewSSTable(cfg, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, sst)
+	assert.Equal(t, filepath.Join(tempDir, "sst_1.db"), sst.path)
+
+	// Check if the file was created
+	_, err = os.Stat(sst.path)
+	assert.NoError(t, err)
+}
+
+func TestSSTableWriteEntry(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{SSTDir: tempDir}
+
+	sst, _ := NewSSTable(cfg, 1)
+
+	err := sst.writeEntry("key1", "value1")
+	assert.NoError(t, err)
+
+	err = sst.writeEntry("key2", "value2")
+	assert.NoError(t, err)
+
+	// Read the file contents and verify
+	data, err := os.ReadFile(sst.path)
+	assert.NoError(t, err)
+
+	expected := []byte{
+		4, 0, 0, 0, // key1 length
+		'k', 'e', 'y', '1',
+		6, 0, 0, 0, // value1 length
+		'v', 'a', 'l', 'u', 'e', '1',
+		4, 0, 0, 0, // key2 length
+		'k', 'e', 'y', '2',
+		6, 0, 0, 0, // value2 length
+		'v', 'a', 'l', 'u', 'e', '2',
+	}
+
+	assert.Equal(t, expected, data)
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 func TestKVStore(t *testing.T) {
+	//TODO use t.tempDir()
 	tempDir, err := os.MkdirTemp("", "kvstore_test")
 	require.NoError(t, err, "Failed to create temp directory")
 	defer os.RemoveAll(tempDir)
 
 	cfg := &config.Config{
 		WALDir: tempDir,
+		SSTDir: tempDir,
 	}
 
 	store, err := NewKVStore(cfg)


### PR DESCRIPTION
Initial LSM + SST implementation

- Create an in-memory data structure (skip list) to serve as the Memtable
- Implement basic insert and update operations for the Memtable
- Implement SST file creation
  - Create a basic SST file format
  - Implement a function to flush the Memtable to an SST file when it reaches a certain size
- Implement the write path
  - append the operation to the WAL
  - insert the key-value pair into the Memtable
  - update the write path to flush the Memtable to an SST file when necessary


Refer:
- https://docs.yugabyte.com/preview/architecture/docdb/lsm-sst/
- https://github.com/google/leveldb/blob/main/doc/table_format.md
- https://github.com/facebook/rocksdb/wiki/Rocksdb-BlockBasedTable-Format
- https://dgraph.io/docs/design-concepts/wal-memtable-concept/